### PR TITLE
docs: consume DelEx shared object model in boards

### DIFF
--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,26 @@
+# START HERE — DelEx Boards
+
+This repository projects the upstream DelEx object model into portfolio, roadmap, and delivery-board semantics.
+
+## Read in this order
+
+1. `docs/README.md`
+2. `docs/portfolio-object-model.md`
+3. `docs/gates-and-board-fields.md`
+4. `docs/service-delivery-projection.md`
+
+## Important rule
+
+Board states, fields, and item types should derive from upstream DelEx objects.
+
+Do not invent local semantics for:
+- readiness
+- approval
+- release
+- exception severity
+- autonomy expansion
+
+## Upstream dependencies
+
+- `delivery-excellence` for canon
+- `delivery-excellence-automation` for schemas and examples

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# DelEx Boards Consumption Layer
+
+This repo is not the place to invent workflow semantics.
+
+Its job is to project the upstream DelEx object model into portfolio, roadmap, and delivery board surfaces.
+
+## Upstream sources of truth
+
+- `SocioProphet/delivery-excellence` for prose canon, gates, action classes, and governance method
+- `SocioProphet/delivery-excellence-automation` for schemas, examples, and contract validation
+
+## Primary docs here
+
+1. [Portfolio Object Model](portfolio-object-model.md)
+2. [Gates and Board Fields](gates-and-board-fields.md)
+3. [Service Delivery Projection](service-delivery-projection.md)
+
+## Design rule
+
+A board column, card field, status rollup, or roadmap view in this repo should map to an upstream object rather than silently define new control semantics.

--- a/docs/gates-and-board-fields.md
+++ b/docs/gates-and-board-fields.md
@@ -1,0 +1,79 @@
+# Gates and Board Fields
+
+## Principle
+
+Board fields should expose DelEx control semantics rather than blur them into generic workflow labels.
+
+## Required fields by board item type
+
+### Engagement
+- engagement_id
+- service_offer_id
+- sponsor
+- process_owner
+- current_gate
+- current_autonomy_classes
+- KPI baseline summary
+
+### Control Loop / Delivery Workstream
+- control_loop_id
+- linked_engagement
+- trigger
+- action classes in scope
+- approval rule
+- exception route
+- KPI targets
+
+### Dependency
+- dependency_id
+- system
+- owner
+- access_state
+- criticality
+- blockers
+
+### Gate Review
+- review_id
+- gate_id
+- engagement_id
+- current_action_classes
+- maturity_scores
+- decision
+- follow-up actions
+
+### Exception
+- exception_id
+- severity
+- human_owner
+- stop_work flag
+- rollback_considered flag
+
+### Reusable Asset
+- asset_id
+- asset_type
+- owning_group
+- source engagements
+- readiness_status
+
+## Gate-driven state model
+
+Suggested board states should be derived from gates, for example:
+- mobilizing
+- readiness-baseline
+- control-design
+- shadow-ready
+- controlled-action-pilot
+- value-review
+
+## Evidence fields
+
+Every board item type should support links to:
+- ADRs
+- PRs
+- dashboards
+- runbooks
+- validation reports
+
+## Escalation visibility
+
+A blocked dependency, high-severity exception, or failed gate review should be board-visible and queryable, not trapped in comments or external chat.

--- a/docs/portfolio-object-model.md
+++ b/docs/portfolio-object-model.md
@@ -1,0 +1,61 @@
+# Portfolio Object Model
+
+## Purpose
+
+`delivery-excellence-boards` consumes upstream DelEx objects and projects them onto planning and execution surfaces.
+
+## Objects this repo must consume
+
+### Engagement
+Represents a client-specific delivery instance.
+
+Board projection:
+- one engagement card or epic
+- contains sponsor, owners, current gate, current autonomy classes, KPI baseline
+- anchors all related delivery work
+
+### Control Loop
+Represents the governed unit of execution.
+
+Board projection:
+- one workstream or nested epic under the engagement
+- contains trigger, tools, action classes, approval rule, exception route, KPI targets
+
+### Delivery Gate
+Represents release/control checkpoints.
+
+Board projection:
+- explicit status/state field, not hidden ceremony
+- gate cards or milestones should carry maturity thresholds and evidence requirements
+
+### Client Dependency
+Represents client-side prerequisites that can block work.
+
+Board projection:
+- dependency cards with owner, access state, blockers, and criticality
+- must be visible in delivery views, not buried in notes
+
+### Board Item
+Represents the operational card primitive.
+
+Board projection:
+- item type determines field set and evidence expectations
+- examples: engagement, dependency, exception, gate review, delivery work, reusable asset
+
+### Exception Class
+Represents recurring failure or escalation patterns.
+
+Board projection:
+- exception cards or linked issue classes
+- severity and human owner must remain visible
+
+## Anti-patterns
+
+Do not let the board tool define its own hidden meanings for:
+- readiness
+- approval
+- release
+- exception severity
+- autonomy expansion
+
+Those semantics must stay derived from upstream DelEx objects.

--- a/docs/service-delivery-projection.md
+++ b/docs/service-delivery-projection.md
@@ -1,0 +1,39 @@
+# Service Delivery Projection
+
+## Worked example: customer success / support accelerator
+
+This repo should be able to project the upstream example bundle into concrete board surfaces without redefining its meaning.
+
+## Example projection
+
+### Portfolio level
+- Engagement epic: `eng.customer-success.support-001`
+- Goal: governed support acceleration with staged autonomy
+- Current gate: `gate.readiness-baseline`
+
+### Workstream level
+- Control loop workstream: `cl.customer-success.support-intake`
+- Key tracks:
+  - retrieval and context assembly
+  - draft response flow
+  - approval-gated routing
+  - exception handling and telemetry
+
+### Dependency lane
+- `dep.crm-access`
+- `dep.kb-corpus`
+
+### Gate review lane
+- `gate.readiness-baseline`
+- `gate.controlled-action-pilot`
+
+### Exception lane
+- `exc.policy-ambiguity`
+- `exc.missing-context`
+
+### Asset lane
+- `asset.cs-support-autonomy-envelope-template`
+
+## What this repo should eventually do
+
+When the open-source board stack is chosen, these objects should become first-class board cards, views, or synced records. The board stack is a renderer and query surface, not the authority on delivery semantics.


### PR DESCRIPTION
## Summary

Map the stabilized DelEx shared object model into `delivery-excellence-boards` so board semantics are derived from upstream canon and contracts rather than invented locally.

## Adds

- docs index for boards as a DelEx consumption layer
- portfolio object-model mapping
- gate and board field mapping
- worked service-delivery projection for the customer-success/support accelerator

## Why

`delivery-excellence` now defines the shared object model and `delivery-excellence-automation` now validates the contract layer. `delivery-excellence-boards` should consume that model and render it into portfolio / roadmap / delivery surfaces.

## Follow-up

- align the open-source Aha-style stack selection to this object model
- ensure future board implementation treats gates, dependencies, exceptions, and assets as first-class records
