### PR TITLE
Add PI Gate 4 board rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # delivery-excellence-boards
 
-Deployment + integration for our open-source Aha-style stack (ideas intake, delivery boards, roadmap).
+Deployment + integration for our open-source Aha-style stack: ideas intake, delivery boards, and roadmap.
+
+## Professional Intelligence OS
+
+Gate 4 rollup:
+
+- `boards/professional-intelligence-gate4-rollup.md`
+
+This rollup tracks the current Professional Intelligence OS Gate 4 board state, including completion percentages, completed board items, source references, and next board items.

--- a/boards/professional-intelligence-gate4-rollup.md
+++ b/boards/professional-intelligence-gate4-rollup.md
@@ -1,0 +1,33 @@
+# Professional Intelligence OS Gate 4 Rollup
+
+## Status
+
+Gate 4 is active.
+
+## Completion readout
+
+- Overall alignment: 74%
+- Demo readiness: 80%
+- Runtime implementation: 52%
+- Cybernetic controls: 58%
+
+## Completed board items
+
+- Platform Gate 4 orchestration.
+- Platform Gate 4 verifier.
+- Platform dashboard control export.
+- Web dashboard state generator.
+
+## Source references
+
+- SocioProphet/prophet-platform#424
+- SocioProphet/prophet-platform#427
+- SocioProphet/prophet-platform#430
+- mdheller/socioprophet-web#24
+- SocioProphet/delivery-excellence#19
+
+## Next board items
+
+1. Governance/control-plane assessment.
+2. Agentplane host-smoke inclusion in platform runner.
+3. Operator artifact surface for verification outputs.


### PR DESCRIPTION
## Summary

Adds a Professional Intelligence OS Gate 4 board rollup.

Adds:
- `boards/professional-intelligence-gate4-rollup.md`

Updates:
- `README.md`

## Current readout

- Overall alignment: ~74%
- Demo readiness: ~80%
- Runtime implementation: ~52%

## Validation

Docs/board rollup only.